### PR TITLE
feat(dispose-order): change dispose order to a stack

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,10 +10,7 @@
       "name": "Unit tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
-        "-u",
-        "tdd",
-        "--timeout",
-        "999999",
+        "--no-timeout",
         "--colors",
         "${workspaceFolder}/test/helpers/**/*.js",
         "${workspaceFolder}/test/unit/**/*.js"
@@ -30,10 +27,7 @@
       "name": "Integration tests",
       "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
       "args": [
-        "-u",
-        "tdd",
-        "--timeout",
-        "999999",
+        "--no-timeout",
         "--colors",
         "${workspaceFolder}/test/helpers/**/*.js",
         "${workspaceFolder}/test/integration/**/*.js"

--- a/src/InjectorImpl.ts
+++ b/src/InjectorImpl.ts
@@ -146,9 +146,9 @@ abstract class ChildInjector<TParentContext, TProvided, CurrentToken extends str
 
   public dispose() {
     if (!this.isDisposed) {
-      this.parent.dispose();
       this.isDisposed = true;
       this.disposables.forEach(disposable => disposable.dispose());
+      this.parent.dispose();
     }
   }
 

--- a/src/api/Disposable.ts
+++ b/src/api/Disposable.ts
@@ -1,3 +1,3 @@
 export interface Disposable {
-  dispose(): void;
+  dispose(): void | Promise<void>;
 }


### PR DESCRIPTION
Change the dispose order to a stack approach. This makes much more sense. Before, we might dispose the dependents of a class before the class itself.