### PR TITLE
feat(node 6): drop support for node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git+https://github.com/nicojs/typed-inject.git"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "keywords": [
     "typescript",

--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -3,7 +3,7 @@
     "composite": true,
     "declarationMap": true,
     "module": "commonjs",
-    "target": "es2015",
+    "target": "es2017",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "rootDir": ".",


### PR DESCRIPTION
This change makes TypeScript output es2017 compatible JavaScript.

BREAKING CHANGE: Node 6 is no longer supported.