### PR TITLE
feat(decorator): add decorator functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,43 @@ In the example above, a child injector is created. It can provide values for the
 The `rootInjector` always remains stateless. So don't worry about reusing it in your tests or reusing it for different parts of your application. However,
 any ChildInjector _is stateful_. For example, it can [cache the injected value](#-control-lifecycle) or [keep track of stuff to dispose](#-disposing-provided-stuff)
 
+## 🎄 Decorate your dependencies
+
+A common use case for dependency injection is the [decorator design pattern](https://en.wikipedia.org/wiki/Decorator_pattern). It is used to dynamically add functionality to existing dependencies. Typed inject supports decoration of existing dependencies using its `provideFactory` and `provideClass` methods.
+
+```ts
+import { tokens, rootInjector } from 'typed-inject';
+
+class Foo {
+  public bar() {
+    console.log ('bar!');
+  }
+}
+
+function fooDecorator(foo: Foo) {
+  return {
+    bar() {
+      console.log('before call');
+      foo.bar();
+      console.log('after call');
+    }
+  };
+}
+fooDecorator.inject = tokens('foo');
+
+const fooProvider = rootInjector
+  .provideClass('foo', Foo)
+  .provideFactory('foo', fooDecorator);
+const foo = fooProvider.resolve('foo');
+
+foo.bar();
+// => "before call"
+// => "bar!"
+// => "after call"
+```
+
+In this example above the `Foo` class is decorated by the `fooDecorator`.
+
 ## ♻ Control lifecycle
 
 You can determine the lifecycle of dependencies with the third `Scope` parameter of `provideFactory` and `provideClass` methods.

--- a/src/api/Injector.ts
+++ b/src/api/Injector.ts
@@ -1,15 +1,17 @@
 import { InjectableClass, InjectableFunction } from './Injectable';
 import { InjectionToken } from './InjectionToken';
 import { Scope } from './Scope';
+import { TChildContext } from './TChildContext';
 
 export interface Injector<TContext = {}> {
   injectClass<R, Tokens extends InjectionToken<TContext>[]>(Class: InjectableClass<TContext, R, Tokens>): R;
   injectFunction<R, Tokens extends InjectionToken<TContext>[]>(Class: InjectableFunction<TContext, R, Tokens>): R;
   resolve<Token extends keyof TContext>(token: Token): TContext[Token];
-  provideValue<Token extends string, R>(token: Token, value: R): Injector<{ [k in Token]: R } & TContext>;
+  provideValue<Token extends string, R>(token: Token, value: R)
+    : Injector<TChildContext<TContext, R, Token>>;
   provideClass<Token extends string, R, Tokens extends InjectionToken<TContext>[]>(token: Token, Class: InjectableClass<TContext, R, Tokens>, scope?: Scope)
-    : Injector<{ [k in Token]: R } & TContext>;
+    : Injector<TChildContext<TContext, R, Token>>;
   provideFactory<Token extends string, R, Tokens extends InjectionToken<TContext>[]>(token: Token, factory: InjectableFunction<TContext, R, Tokens>, scope?: Scope)
-    : Injector<{ [k in Token]: R } & TContext>;
+    : Injector<TChildContext<TContext, R, Token>>;
   dispose(): Promise<void>;
 }

--- a/src/api/TChildContext.ts
+++ b/src/api/TChildContext.ts
@@ -1,0 +1,3 @@
+export type TChildContext<TParentContext, TProvided, CurrentToken extends string> = {
+  [K in keyof (TParentContext & { [K in CurrentToken]: TProvided })]: K extends CurrentToken ? TProvided : K extends keyof TParentContext ? TParentContext[K]: never;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './api/CorrespondingType';
 export * from './api/InjectionToken';
 export * from './api/Injector';
 export * from './api/Scope';
+export * from './api/TChildContext';
 export * from './InjectorImpl';
 export * from './tokens';
 export * from './api/Disposable';

--- a/testResources/override-token-should-change-type.ts
+++ b/testResources/override-token-should-change-type.ts
@@ -1,0 +1,9 @@
+// error: "Type 'string' is not assignable to type 'number'"
+
+import { rootInjector } from '../src/index';
+
+const fooProvider = rootInjector
+  .provideValue('foo', 42)
+  .provideValue('foo', 'bar');
+
+const foo: number = fooProvider.resolve('foo');

--- a/testResources/tokens-of-type-string.ts
+++ b/testResources/tokens-of-type-string.ts
@@ -1,4 +1,4 @@
-// error: "Type 'string[]' is not assignable to type 'InjectionToken<{ bar: number; }>[]"
+// error: "Type 'string[]' is not assignable to type 'InjectionToken<TChildContext<{}, number, \"bar\">>[]'"
 
 import { rootInjector } from '../src/index';
 


### PR DESCRIPTION
Add the ability to override a token. Previously this resulted in a stack overflow error when resolving the token.

```ts
     const answerProvider = rootInjector
        .provideValue('answer', 42)
        .provideValue('answer', '42');
      expect(answerProvider.resolve('answer')).eq('42');
      expect(typeof answerProvider.resolve('answer')).eq('string');
```

With this functionality in place, it is now also possible to add decorators to existing dependencies. See readme for more info.