### PR TITLE
fix(tslib): remove implicit dependency on tslib

### DIFF
--- a/tsconfig.settings.json
+++ b/tsconfig.settings.json
@@ -11,7 +11,7 @@
     "declaration": true,
     "forceConsistentCasingInFileNames": true,
     "allowJs": false,
-    "importHelpers": true,
+    "importHelpers": false,
     "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Until now, typed-inject implicitly depended on tslib. Not depending on tslib yourself could result in this error:

```
internal/modules/cjs/loader.js:584
    throw err;
    ^

Error: Cannot find module 'tslib'
    at Function.Module._resolveFilename (internal/module
```
