### PR TITLE
feat(as const): allow to declare tokens as const

### DIFF
--- a/src/api/CorrespondingType.ts
+++ b/src/api/CorrespondingType.ts
@@ -9,6 +9,6 @@ export type CorrespondingType<TContext, T extends InjectionToken<TContext>> = T 
   ? TContext[T]
   : never;
 
-export type CorrespondingTypes<TContext, TS extends InjectionToken<TContext>[]> = {
+export type CorrespondingTypes<TContext, TS extends readonly InjectionToken<TContext>[]> = {
   [K in keyof TS]: TS[K] extends InjectionToken<TContext> ? CorrespondingType<TContext, TS[K]> : never;
 };

--- a/src/api/Injectable.ts
+++ b/src/api/Injectable.ts
@@ -1,28 +1,28 @@
 import { CorrespondingTypes } from './CorrespondingType';
 import { InjectionToken } from './InjectionToken';
 
-export type InjectableClass<TContext, R, Tokens extends InjectionToken<TContext>[]> =
+export type InjectableClass<TContext, R, Tokens extends readonly InjectionToken<TContext>[]> =
   | ClassWithInjections<TContext, R, Tokens>
   | ClassWithoutInjections<R>;
 
-export interface ClassWithInjections<TContext, R, Tokens extends InjectionToken<TContext>[]> {
+export interface ClassWithInjections<TContext, R, Tokens extends readonly InjectionToken<TContext>[]> {
   new (...args: CorrespondingTypes<TContext, Tokens>): R;
   readonly inject: Tokens;
 }
 
 export type ClassWithoutInjections<R> = new () => R;
 
-export type InjectableFunction<TContext, R, Tokens extends InjectionToken<TContext>[]> =
+export type InjectableFunction<TContext, R, Tokens extends readonly InjectionToken<TContext>[]> =
   | InjectableFunctionWithInject<TContext, R, Tokens>
   | InjectableFunctionWithoutInject<R>;
 
-export interface InjectableFunctionWithInject<TContext, R, Tokens extends InjectionToken<TContext>[]> {
+export interface InjectableFunctionWithInject<TContext, R, Tokens extends readonly InjectionToken<TContext>[]> {
   (...args: CorrespondingTypes<TContext, Tokens>): R;
   readonly inject: Tokens;
 }
 
 export type InjectableFunctionWithoutInject<R> = () => R;
 
-export type Injectable<TContext, R, Tokens extends InjectionToken<TContext>[]> =
+export type Injectable<TContext, R, Tokens extends readonly InjectionToken<TContext>[]> =
   | InjectableClass<TContext, R, Tokens>
   | InjectableFunction<TContext, R, Tokens>;

--- a/src/api/Injector.ts
+++ b/src/api/Injector.ts
@@ -4,16 +4,16 @@ import { Scope } from './Scope';
 import { TChildContext } from './TChildContext';
 
 export interface Injector<TContext = {}> {
-  injectClass<R, Tokens extends InjectionToken<TContext>[]>(Class: InjectableClass<TContext, R, Tokens>): R;
-  injectFunction<R, Tokens extends InjectionToken<TContext>[]>(Class: InjectableFunction<TContext, R, Tokens>): R;
+  injectClass<R, Tokens extends readonly InjectionToken<TContext>[]>(Class: InjectableClass<TContext, R, Tokens>): R;
+  injectFunction<R, Tokens extends readonly InjectionToken<TContext>[]>(Class: InjectableFunction<TContext, R, Tokens>): R;
   resolve<Token extends keyof TContext>(token: Token): TContext[Token];
   provideValue<Token extends string, R>(token: Token, value: R): Injector<TChildContext<TContext, R, Token>>;
-  provideClass<Token extends string, R, Tokens extends InjectionToken<TContext>[]>(
+  provideClass<Token extends string, R, Tokens extends readonly InjectionToken<TContext>[]>(
     token: Token,
     Class: InjectableClass<TContext, R, Tokens>,
     scope?: Scope
   ): Injector<TChildContext<TContext, R, Token>>;
-  provideFactory<Token extends string, R, Tokens extends InjectionToken<TContext>[]>(
+  provideFactory<Token extends string, R, Tokens extends readonly InjectionToken<TContext>[]>(
     token: Token,
     factory: InjectableFunction<TContext, R, Tokens>,
     scope?: Scope

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -7,6 +7,6 @@
  * ```
  * @param tokens The tokens as args
  */
-export function tokens<TS extends string[]>(...tokens: TS): TS {
+export function tokens<TS extends readonly string[]>(...tokens: TS): TS {
   return tokens;
 }

--- a/testResources/dependency-graph-as-const.ts
+++ b/testResources/dependency-graph-as-const.ts
@@ -1,0 +1,20 @@
+// error: false
+import { rootInjector } from '../src/index';
+
+class Baz {
+  public baz = 'baz';
+}
+
+function bar(baz: Baz) {
+  return { baz };
+}
+bar.inject = ['baz'] as const;
+
+class Foo {
+  constructor(public bar: { baz: Baz }, public baz: Baz, public qux: boolean) {}
+  public static inject = ['bar', 'baz', 'qux'] as const;
+}
+
+const fooInjector = rootInjector.provideValue('qux', true).provideClass('baz', Baz).provideFactory('bar', bar);
+
+const foo: Foo = fooInjector.injectClass(Foo);

--- a/testResources/tokens-of-type-string.ts
+++ b/testResources/tokens-of-type-string.ts
@@ -1,1 +1,9 @@
-// error: "Type 'string[]' is not assignable to type 'InjectionToken<TChildContext<{}, number, \"bar\">>[]'"import { rootInjector } from '../src/index';class Foo {  constructor(bar: number) {}  public static inject = ['bar'];}const foo: Foo = rootInjector.provideValue('bar', 42).injectClass(Foo);
+// error: "Type 'string[]' is not assignable to type 'readonly InjectionToken<TChildContext<{}, number, \"bar\">>[]'"
+
+import { rootInjector } from '../src/index';
+
+class Foo {
+  constructor(bar: number) {}
+  public static inject = ['bar'];
+}
+const foo: Foo = rootInjector.provideValue('bar', 42).injectClass(Foo);

--- a/testResources/unknown-token.ts
+++ b/testResources/unknown-token.ts
@@ -1,1 +1,8 @@
-// error: "Type '[\"not-exists\"]' is not assignable to type 'InjectionToken<{}>[]"import { rootInjector, tokens } from '../src/index';function foo(bar: string) {}foo.inject = tokens('not-exists');rootInjector.injectFunction(foo);
+// error: "Type '[\"not-exists\"]' is not assignable to type 'readonly InjectionToken<{}>[]"
+
+import { rootInjector, tokens } from '../src/index';
+
+function foo(bar: string) {}
+foo.inject = tokens('not-exists');
+
+rootInjector.injectFunction(foo);


### PR DESCRIPTION
Allow to declare tokens as const.

This:

```ts
class Foo {
  static inject = tokens('bar');
}
```

Can now also be specified as:

```ts
class Foo {
  static inject = ['bar'] as const;
}
```

Fixes #23 

BREAKING CHANGE: The typed-inject is now expecting tokens to be provided in a `readonly` array. You can either use `as const` or the `tokens` helper function for it.