### PR TITLE
feat(dispose): dispose child injectors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,13 +21,12 @@
       "args": [
         "--no-timeout",
         "--colors",
-        "${workspaceFolder}/test/helpers/**/*.js",
-        "${workspaceFolder}/test/unit/**/*.js"
+        "${workspaceFolder}/dist/test/helpers/**/*.js",
+        "${workspaceFolder}/dist/test/unit/**/*.js"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "outFiles": [
-        "${workspaceRoot}/test/**/*.js",
-        "${workspaceRoot}/src/**/*.js"
+        "${workspaceRoot}/dist/**/*.js"
       ]
     },
     {
@@ -38,13 +37,12 @@
       "args": [
         "--no-timeout",
         "--colors",
-        "${workspaceFolder}/test/helpers/**/*.js",
-        "${workspaceFolder}/test/integration/**/*.js"
+        "${workspaceFolder}/dist/test/helpers/**/*.js",
+        "${workspaceFolder}/dist/test/integration/**/*.js"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "outFiles": [
-        "${workspaceRoot}/test/**/*.js",
-        "${workspaceRoot}/src/**/*.js"
+        "${workspaceRoot}/dist/**/*.js"
       ]
     }
   ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,8 @@
     "javascript",
     "typescript"
   ],
-  "typescript.tsdk": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules\\typescript\\lib",
+  "cSpell.words": [
+    "Typesafe"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 # Typed Inject
 
-> Type safe dependency injection for TypeScript
+> Typesafe dependency injection for TypeScript
 
-A tiny, 100% type safe dependency injection framework for TypeScript. You can inject classes, interfaces or primitives. If your project compiles, you know for sure your dependencies are resolved at runtime and have their declared types.
+A tiny, 100% typesafe dependency injection framework for TypeScript. You can inject classes, interfaces, or primitives. If your project compiles, you know your dependencies are resolved at runtime and have their declared types.
 
 _If you are new to 'Dependency Injection'/'Inversion of control', please read up on it [in this blog article about it](https://medium.com/@samueleresca/inversion-of-control-and-dependency-injection-in-typescript-3040d568aabe)_
 
@@ -18,11 +18,11 @@ _If you want to know more about how typed-inject works, please read [my blog art
 * [🗺️ Installation](#installation)
 * [🎁 Usage](#usage)
 * [💭 Motivation](#motivation)
-* [🗝️ Type safe? How?](#type-safe-how)
+* [🗝️ Typesafe? How?](#typesafe-how)
 * [👶 Child injectors](#child-injectors)
 * [🎄 Decorate your dependencies](#decorate-your-dependencies)
 * [♻ Lifecycle control](#lifecycle-control)
-* [🚮 Disposing provided stuff](#disposing-provided-stuff)
+* [🚮 Disposing of provided stuff](#disposing-of-provided-stuff)
 * [✨ Magic tokens](#magic-tokens)
 * [😬 Error handling](#error-handling)
 * [📖 API reference](#api-reference)
@@ -55,7 +55,7 @@ _Note: due to a [bug in TypeScript 3.8](https://github.com/microsoft/TypeScript/
 An example:
 
 ```ts
-import { rootInjector } from 'typed-inject';
+import { createInjector } from 'typed-inject';
 
 interface Logger {
   info(message: string): void;
@@ -77,7 +77,7 @@ class MyService {
   public static inject = ['httpClient', 'logger'] as const;
 }
 
-const appInjector = rootInjector.provideValue('logger', logger).provideClass('httpClient', HttpClient);
+const appInjector = createInjector().provideValue('logger', logger).provideClass('httpClient', HttpClient);
 
 const myService = appInjector.injectClass(MyService);
 // Dependencies for MyService validated and injected
@@ -88,12 +88,12 @@ In this example:
 - The `logger` is injected into a new instance of `HttpClient` by value.
 - The instance of `HttpClient` and the `logger` are injected into a new instance of `MyService`.
 
-Dependencies are resolved using the static `inject` property on their classes. They must match the names given to the dependencies when configuring the injector with `provideXXX` methods.
+Dependencies are resolved using the static `inject` property in their classes. They must match the names given to the dependencies when configuring the injector with `provideXXX` methods.
 
 Expect compiler errors when you mess up the order of tokens or forget it completely.
 
 ```ts
-import { rootInjector } from 'typed-inject';
+import { createInjector } from 'typed-inject';
 
 // Same logger as before
 
@@ -108,7 +108,7 @@ class MyService {
   // ERROR! Types of parameters 'http' and 'args_0' are incompatible
 }
 
-const appInjector = rootInjector.provideValue('logger', logger).provideClass('httpClient', HttpClient);
+const appInjector = createInjector().provideValue('logger', logger).provideClass('httpClient', HttpClient);
 
 const myService = appInjector.injectClass(MyService);
 ```
@@ -123,17 +123,17 @@ JavaScript and TypeScript development already has a great dependency injection s
 
 ### InversifyJS uses Reflect-metadata
 
-InversifyJS works with a nice API using decorators. Decorators is in Stage 2 of ecma script proposal at the moment of writing this, so will most likely land in ESNext. However, it also is opinionated in that it requires you to use [reflect-metadata](https://rbuckton.github.io/reflect-metadata/), which [is supposed to be an ecma script proposal, but isn't yet (at the moment of writing this)](https://github.com/rbuckton/reflect-metadata/issues/96). It might take years for reflect-metadata to land in Ecma script, if it ever does.
+InversifyJS works with a nice API using decorators. Decorators are in Stage 2 of ecma script proposal at the moment of writing this, so they will most likely land in ESNext. However, it also is opinionated in that it requires you to use [reflect-metadata](https://rbuckton.github.io/reflect-metadata/), which [is supposed to be an ecma script proposal, but isn't yet (at the moment of writing this)](https://github.com/rbuckton/reflect-metadata/issues/96). It might take years for reflect-metadata to land in JavaScript, if it ever does.
 
-### InversifyJS is not type-safe
+### InversifyJS is not typesafe
 
-InversifyJS is also _not_ type-safe. There is no check to see of the injected type is actually injectable or that the corresponding type adheres to the expected type.
+InversifyJS is also _not_ typesafe. There is no check to see of the injected type is actually injectable or that the corresponding type adheres to the expected type.
 
-<a name="type-safe-how"></a>
+<a name="typesafe-how"></a>
 
-## 🗝️ Type safe? How?
+## 🗝️ Typesafe? How?
 
-Type safe dependency injection works by combining awesome TypeScript features. Some of those features are:
+Type safe dependency injection works by combining excellent TypeScript features. Some of those features are:
 
 - [Literal types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#string-literal-types)
 - [Intersection types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#intersection-types)
@@ -147,12 +147,12 @@ Please read [my blog article on Medium](https://medium.com/@jansennico/advanced-
 
 ## 👶 Child injectors
 
-The `Injector` interface is responsible for injecting classes or functions. However, `typed-inject` only comes with one implementation: the `rootInjector`. It can't provide any dependencies directly (expect for [magic tokens](#-magic-tokens)).
+The `Injector` interface is responsible for injecting classes or functions. You start off with an empty injector after calling `createInjector`. It can't provide any dependencies directly (expect for [magic tokens](#-magic-tokens)).
 
-In order to do anything useful with the `rootInjector`, you'll need to create child injectors. This what you do with the `provideXXX` methods.
+To do anything useful with your injector, you'll need to create child injectors. This what you do with the `provideXXX` methods.
 
 ```ts
-import { rootInjector } from 'typed-inject';
+import { createInjector } from 'typed-inject';
 function barFactory(foo: number) {
   return foo + 1;
 }
@@ -164,16 +164,23 @@ class Baz {
   static inject = ['bar'] as const;
 }
 
-const childInjector = rootInjector
-  .provideValue('foo', 42)
-  .provideFactory('bar', barFactory)
-  .provideClass('baz', Baz);
+// Create 3 child injectors here
+const childInjector = createInjector()
+  .provideValue('foo', 42) // child injector can provide 'foo'
+  .provideFactory('bar', barFactory) // child injector can provide both 'bar' and 'foo'
+  .provideClass('baz', Baz); // child injector can provide 'baz', 'bar' and 'foo'
+
+// Now use it here
+function run(baz: Baz) {
+  // baz is created!
+}
+run.inject = ['baz'] as const;
+childInjector.injectFunction(run);
 ```
 
 In the example above, a child injector is created. It can provide values for the tokens `'foo'`, `'bar'` and `'baz'`. You can create as many child injectors as you want.
 
-The `rootInjector` always remains stateless. So don't worry about reusing it in your tests or reusing it for different parts of your application. However,
-any ChildInjector _is stateful_. For example, it can [cache the injected value](#-control-lifecycle) or [keep track of stuff to dispose](#-disposing-provided-stuff)
+Injectors keep track of their child injectors and values they've injected. This way it can provide functionality like [cache the injected value](#-control-lifecycle) or [keep track of stuff to dispose](#-disposing-provided-stuff).
 
 <a name="decorate-your-dependencies"></a>
 
@@ -182,7 +189,7 @@ any ChildInjector _is stateful_. For example, it can [cache the injected value](
 A common use case for dependency injection is the [decorator design pattern](https://en.wikipedia.org/wiki/Decorator_pattern). It is used to dynamically add functionality to existing dependencies. Typed inject supports decoration of existing dependencies using its `provideFactory` and `provideClass` methods.
 
 ```ts
-import { rootInjector } from 'typed-inject';
+import { createInjector } from 'typed-inject';
 
 class Foo {
   public bar() {
@@ -201,7 +208,7 @@ function fooDecorator(foo: Foo) {
 }
 fooDecorator.inject = ['foo'] as const;
 
-const fooProvider = rootInjector.provideClass('foo', Foo).provideFactory('foo', fooDecorator);
+const fooProvider = createInjector().provideClass('foo', Foo).provideFactory('foo', fooDecorator);
 const foo = fooProvider.resolve('foo');
 
 foo.bar();
@@ -244,20 +251,20 @@ A scope has 2 possible values.
   Use `Scope.Singleton` to enable caching. Every time the dependency needs to be provided by the injector, the same instance is returned. Other injectors will still create their own instances, so it's only a `Singleton` for the specific injector (and child injectors created from it). In other words,
   the instance will be _scoped to the `Injector`_
 - `Scope.Transient`  
-  Use `Scope.Transient` to completely disable cashing. You'll always get fresh instances.
+  Use `Scope.Transient` to altogether disable cashing. You'll always get fresh instances.
 
 <a name="disposing-provided-stuff"></a>
 
 ## 🚮 Disposing provided stuff
 
-Memory in JavaScript is garbage collected, so usually we don't care about cleaning up after ourselves. However, there might be a need to explicit clean up. For example removing a temp folder, or killing a child process.
+Memory in JavaScript is garbage collected, so, we usually don't care about cleaning up after ourselves. However, there might be a need to explicit cleanup. For example removing a temp folder, or killing a child process.
 
 As `typed-inject` is responsible for creating (providing) your dependencies, it only makes sense it is also responsible for the disposing of them.
 
-Any `Injector` has a `dispose` method. If you call it, the injector in turn will call `dispose` on any instance that he provided (if it has one).
+Any `Injector` has a `dispose` method. Calling it will call `dispose` on any instance that was ever provided from it, as well as any child injectors that were created from it.
 
 ```ts
-import { rootInjector } from 'typed-inject';
+import { createInjector } from 'typed-inject';
 
 class Foo {
   constructor() {
@@ -267,11 +274,14 @@ class Foo {
     console.log('Foo disposed');
   }
 }
+const rootInjector = createInjector();
 const fooProvider = rootInjector.provideClass('foo', Foo);
 fooProvider.resolve('foo'); // => "Foo created"
-await fooProvider.dispose(); // => "Foo disposed"
+await rootInjector.dispose(); // => "Foo disposed"
 fooProvider.resolve('foo'); // Error: Injector already disposed
 ```
+
+_Note: Always dispose from the top down! In this example, the `rootInjector` is disposed, which in turn disposes everything that was ever provided from one if it's child injectors._
 
 To help you implementing the `dispose` method correctly, `typed-inject` exports the `Disposable` interface for convenience:
 
@@ -288,12 +298,13 @@ You are responsible for the correct handling of the async behavior of the `dispo
 This means you should either `await` the result or attach `then`/`catch` handlers.
 
 ```ts
-import { rootInjector, Disposable } from 'typed-inject';
+import { createInjector, Disposable } from 'typed-inject';
 class Foo implements Disposable {
   dispose(): Promise<void> {
     return Promise.resolve();
   }
 }
+const rootInjector = createInjector();
 const fooProvider = rootInjector
   .provideClass('foo', Foo);
 const foo = fooProvider.resolve('foo');
@@ -305,22 +316,23 @@ disposeFoo()
   .catch(err => console.error('Foo disposal resulted in an error', err);
 ```
 
-Using `dispose` on an injector will automatically dispose it's parent injectors as well:
+Using `dispose` on the rootInjector will automatically dispose it's child injectors as well:
 
 ```ts
-import { rootInjector } from 'typed-inject';
+import { createInjector } from 'typed-inject';
 class Foo {}
 class Bar {}
+const rootInjector = createInjector();
 const fooProvider = rootInjector.provideClass('foo', Foo);
 const barProvider = fooProvider.provideClass('bar', Bar);
-await barProvider.dispose(); // => fooProvider is also disposed!
+await rootInjector.dispose(); // => fooProvider is also disposed!
 fooProvider.resolve('foo'); // => Error: Injector already disposed
 ```
 
 Disposing of provided values is done in order of child first. So they are disposed in the opposite order of respective `providedXXX` calls (like a stack):
 
 ```ts
-import { rootInjector} from 'typed-inject';
+import { createInjector } from 'typed-inject';
 
 class Foo {
   dispose() {
@@ -336,6 +348,7 @@ class Baz {
   static inject = ['foo', 'bar'] as const;
   constructor(public foo: Foo, public bar: Bar) {}
 }
+const rootInjector = createInjector();
 rootInjector
   .provideClass('foo', Foo)
   .provideClass('bar', Bar)
@@ -356,19 +369,19 @@ Any `Injector` instance can always inject the following tokens:
 | Token name       | Token value   | Description                                                                                        |
 | ---------------- | ------------- | -------------------------------------------------------------------------------------------------- |
 | `INJECTOR_TOKEN` | `'$injector'` | Injects the current injector                                                                       |
-| `TARGET_TOKEN`   | `'$target'`   | The class or function in which the current values is injected, or `undefined` if resolved directly |
+| `TARGET_TOKEN`   | `'$target'`   | The class or function in which the current values are injected, or `undefined` if resolved directly |
 
 An example:
 
 ```ts
-import { rootInjector, Injector, TARGET_TOKEN, INJECTOR_TOKEN } from 'typed-inject';
+import { createInjector, Injector, TARGET_TOKEN, INJECTOR_TOKEN } from 'typed-inject';
 
 class Foo {
   constructor(injector: Injector<{}>, target: Function | undefined) {}
   static inject = [INJECTOR_TOKEN, TARGET_TOKEN] as const;
 }
 
-const foo = rootInjector.inject(Foo);
+const foo = createInjector().inject(Foo);
 ```
 
 <a name="error-handling"></a>
@@ -393,7 +406,7 @@ class Parent {
   constructor(public readonly child: Child) {}
   public static inject = ['child'] as const;
 }
-rootInjector
+createInjector()
   .provideClass('grandChild', GrandChild)
   .provideClass('child', Child)
   .injectClass(Parent);
@@ -405,7 +418,7 @@ When you handle the error, you will be able to capture the original `cause`.
 ```ts
 import { InjectionError } from 'typed-inject';
 try {
-  rootInjector
+  createInjector()
     .provideClass('grandChild', GrandChild)
     .provideClass('child', Child)
     .injectClass(Parent);
@@ -422,15 +435,17 @@ try {
 
 _Note: some generic parameters are omitted for clarity._
 
+### `createInjector`
+
+Create a new `Injector<{}>`. You generally want to create one per application/request. If you're using `typed-inject` also in your unit tests, you probably want to create a fresh one for each test, for example in global test setup.
+
 ### `Injector<TContext>`
 
 The `Injector<TContext>` is the core interface of typed-inject. It provides the ability to inject your class or function with `injectClass` and `injectFunction` respectively. You can create new _child injectors_ from it using the `provideXXX` methods.
 
-The `TContext` generic arguments is a [lookup type](https://blog.mariusschulz.com/2017/01/06/typescript-2-1-keyof-and-lookup-types). The keys in this type are the tokens that can be injected, the values are the exact types of those tokens. For example, if `TContext extends { foo: string, bar: number }`, you can let a token `'foo'` be injected of type `string`, and a token `'bar'` of type `number`.
+The `TContext` generic argument is a [lookup type](https://blog.mariusschulz.com/2017/01/06/typescript-2-1-keyof-and-lookup-types). The keys in this type are the tokens that can be injected, the values are the exact types of those tokens. For example, if `TContext extends { foo: string, bar: number }`, you can let a token `'foo'` be injected of type `string`, and a token `'bar'` of type `number`.
 
 Typed inject comes with only one implementation. The `rootInjector`. It implements `Injector<{}>` interface, meaning that it does not provide any tokens (except for [magic tokens](#-magic-tokens)). Import it with `import { rootInjector } from 'typed-inject'`. From the `rootInjector`, you can create child injectors. See [creating child injectors](#-creating-child-injectors) for more information.
-
-Don't worry about reusing the `rootInjector` in your application. It is stateless and read-only, so safe for concurrent use.
 
 #### `injector.injectClass(injectable: InjectableClass)`
 
@@ -482,7 +497,7 @@ const fooInjector = injector.provideValue('foo', 42);
 
 #### `injector.provideFactory(token: Token, factory: InjectableFunction<TContext>, scope = Scope.Singleton): Injector<ChildContext<TContext, Token, R>>`
 
-Create a child injector that can provide a value using `factory` for token `'token'`. The new child injector can resolve all tokens the parent injector can, as well as the new `'token'`.
+Create a child injector that can provide a value using `factory` for token `'token'`. The new child injector can resolve all tokens the parent injector can and the new `'token'`.
 
 With `scope` you can decide whether the value must be cached after the factory is invoked once. Use `Scope.Singleton` to enable caching (default), or `Scope.Transient` to disable caching.
 
@@ -503,13 +518,16 @@ Scope is also supported here, for more info, see `provideFactory`.
 
 #### `injector.dispose(): Promise<void>`
 
-Use `dispose` to explicitly dispose the `injector`. It will call `dispose` on any dependency created by the injector (if it exists) using `provideClass` or `provideFactory` (**not** `provideValue` or `injectXXX`). It will also await any promise that might have been returned by `dispose`. After that, it will `dispose` it's parent injector as well.
+Use `dispose` to explicitly dispose the `injector`. This will result in the following (in order):
+
+1. Call `dispose` on each child injector created from this injector.
+2. It will call `dispose` on any dependency created by the injector (if it exists) using `provideClass` or `provideFactory` (**not** `provideValue` or `injectXXX`). 
+3. It will also await any promise that might have been returned by disposable dependencies. 
 
 _Note: this behavior changed since v2. Before v2, the parent injector was always disposed before the child injector._
+_Note: this behavior changed again in v3, calling `dispose` on a child injector will **no longer** dispose it's parent injector and instead will dispose it's child injectors. The order of disposal is still child first._
 
-After a child injector is disposed, you cannot us it any more. Any attempt to use it will result in a `Injector already disposed` error.
-
-The `rootInjector` will never be disposed.
+After an injector is disposed, you cannot use it anymore. Any attempt to do so will result in an `InjectorDisposedError` error.
 
 Disposing of your dependencies is always done asynchronously. You should take care to handle this appropriately. The best way to do that is to `await` the result of `myInjector.dispose()`.
 
@@ -601,4 +619,4 @@ The original cause of the injection error.
 
 This entire framework would not be possible without the awesome guys working on TypeScript. Guys like [Ryan](https://github.com/RyanCavanaugh), [Anders](https://github.com/ahejlsberg) and the rest of the team: a heartfelt thanks! 💖
 
-Inspiration for the API with static `inject` method comes from years long AngularJS development. Special thanks to the Angular team.
+Inspiration for the API with static `inject` method comes from years-long AngularJS development. Special thanks to the Angular team.

--- a/test/unit/Injector.spec.ts
+++ b/test/unit/Injector.spec.ts
@@ -12,7 +12,7 @@ import * as sinon from 'sinon';
 import { Disposable } from '../../src/api/Disposable';
 import { Task, tick } from '../helpers/Task';
 
-describe.only('InjectorImpl', () => {
+describe('InjectorImpl', () => {
   let rootInjector: Injector<{}>;
 
   beforeEach(() => {

--- a/testResources/dependency-graph-as-const.ts
+++ b/testResources/dependency-graph-as-const.ts
@@ -1,5 +1,5 @@
 // error: false
-import { rootInjector } from '../src/index';
+import { createInjector } from '../src/index';
 
 class Baz {
   public baz = 'baz';
@@ -15,6 +15,6 @@ class Foo {
   public static inject = ['bar', 'baz', 'qux'] as const;
 }
 
-const fooInjector = rootInjector.provideValue('qux', true).provideClass('baz', Baz).provideFactory('bar', bar);
+const fooInjector = createInjector().provideValue('qux', true).provideClass('baz', Baz).provideFactory('bar', bar);
 
 const foo: Foo = fooInjector.injectClass(Foo);

--- a/testResources/dependency-graph.ts
+++ b/testResources/dependency-graph.ts
@@ -1,1 +1,22 @@
-// error: falseimport { rootInjector, tokens } from '../src/index';class Baz {  public baz = 'baz';}function bar(baz: Baz) {  return { baz };}bar.inject = tokens('baz');class Foo {  constructor(public bar: { baz: Baz }, public baz: Baz, public qux: boolean) {}  public static inject = tokens('bar', 'baz', 'qux');}const fooInjector = rootInjector.provideValue('qux', true).provideClass('baz', Baz).provideFactory('bar', bar);const foo: Foo = fooInjector.injectClass(Foo);
+// error: false
+import { createInjector, tokens } from '../src/index';
+
+const rootInjector = createInjector();
+
+class Baz {
+  public baz = 'baz';
+}
+
+function bar(baz: Baz) {
+  return { baz };
+}
+bar.inject = tokens('baz');
+
+class Foo {
+  constructor(public bar: { baz: Baz }, public baz: Baz, public qux: boolean) {}
+  public static inject = tokens('bar', 'baz', 'qux');
+}
+
+const fooInjector = rootInjector.provideValue('qux', true).provideClass('baz', Baz).provideFactory('bar', bar);
+
+const foo: Foo = fooInjector.injectClass(Foo);

--- a/testResources/forgot-tokens-class.ts
+++ b/testResources/forgot-tokens-class.ts
@@ -1,1 +1,8 @@
-// error: "Property 'inject' is missing in type 'typeof Foo'"import { rootInjector, Injector } from '../src/index';rootInjector.injectClass(  class Foo {    constructor(public injector: Function | Injector<{}> | undefined) {}  });
+// error: "Property 'inject' is missing in type 'typeof Foo'"
+import { createInjector, Injector } from '../src/index';
+
+createInjector().injectClass(
+  class Foo {
+    constructor(public injector: Function | Injector<{}> | undefined) {}
+  }
+);

--- a/testResources/forgot-tokens-function.ts
+++ b/testResources/forgot-tokens-function.ts
@@ -1,1 +1,4 @@
-// error: "Property 'inject' is missing in type '(injector: Function | Injector<{}> | undefined) => void' but required"import { rootInjector, Injector } from '../src/index';function foo(injector: Function | Injector<{}> | undefined) {}rootInjector.injectFunction(foo);
+// error: "Property 'inject' is missing in type '(injector: Function | Injector<{}> | undefined) => void' but required"
+import { createInjector, Injector } from '../src/index';
+function foo(injector: Function | Injector<{}> | undefined) {}
+createInjector().injectFunction(foo);

--- a/testResources/injector-too-variant.ts
+++ b/testResources/injector-too-variant.ts
@@ -1,1 +1,6 @@
-// error: "Property 'foo' is missing in type '{}' but required in type '{ foo: string; }'"import { rootInjector, Injector } from '../src/index';const fooInjector: Injector<{ foo: string }> = rootInjector;console.log(fooInjector);
+// error: "Property 'foo' is missing in type '{}' but required in type '{ foo: string; }'"
+
+import { createInjector, Injector } from '../src/index';
+
+const fooInjector: Injector<{ foo: string }> = createInjector();
+console.log(fooInjector);

--- a/testResources/override-token-should-change-type.ts
+++ b/testResources/override-token-should-change-type.ts
@@ -1,1 +1,7 @@
-// error: "Type 'string' is not assignable to type 'number'"import { rootInjector } from '../src/index';const fooProvider = rootInjector.provideValue('foo', 42).provideValue('foo', 'bar');const foo: number = fooProvider.resolve('foo');
+// error: "Type 'string' is not assignable to type 'number'"
+
+import { createInjector } from '../src/index';
+
+const fooProvider = createInjector().provideValue('foo', 42).provideValue('foo', 'bar');
+
+const foo: number = fooProvider.resolve('foo');

--- a/testResources/tokens-of-type-string.ts
+++ b/testResources/tokens-of-type-string.ts
@@ -1,9 +1,9 @@
 // error: "Type 'string[]' is not assignable to type 'readonly InjectionToken<TChildContext<{}, number, \"bar\">>[]'"
 
-import { rootInjector } from '../src/index';
+import { createInjector } from '../src/index';
 
 class Foo {
   constructor(bar: number) {}
   public static inject = ['bar'];
 }
-const foo: Foo = rootInjector.provideValue('bar', 42).injectClass(Foo);
+const foo: Foo = createInjector().provideValue('bar', 42).injectClass(Foo);

--- a/testResources/unknown-token.ts
+++ b/testResources/unknown-token.ts
@@ -1,8 +1,8 @@
 // error: "Type '[\"not-exists\"]' is not assignable to type 'readonly InjectionToken<{}>[]"
 
-import { rootInjector, tokens } from '../src/index';
+import { createInjector, tokens } from '../src/index';
 
 function foo(bar: string) {}
 foo.inject = tokens('not-exists');
 
-rootInjector.injectFunction(foo);
+createInjector().injectFunction(foo);

--- a/testResources/wrong-order-tokens.ts
+++ b/testResources/wrong-order-tokens.ts
@@ -1,1 +1,9 @@
-// error: "Types of parameters 'bar' and 'args_0' are incompatible"import { rootInjector, tokens } from '../src/index';class Foo {  constructor(bar: string, baz: number) {}  public static inject = tokens('baz', 'bar');}const foo: Foo = rootInjector.provideValue('bar', 'bar').provideValue('baz', 42).injectClass(Foo);
+// error: "Types of parameters 'bar' and 'args_0' are incompatible"
+import { createInjector, tokens } from '../src/index';
+
+class Foo {
+  constructor(bar: string, baz: number) {}
+  public static inject = tokens('baz', 'bar');
+}
+
+const foo: Foo = createInjector().provideValue('bar', 'bar').provideValue('baz', 42).injectClass(Foo);


### PR DESCRIPTION
This changes the way `dispose` works. Instead of an `Injector` disposing it's own provided dependencies and then call `dispose` on the parent, it will dispose its child `Injector`'s (that were created using `provideXXX`) and then it's own dependencies. The parent `Injector` will _no longer_ be disposed of.

This allows you to dispose from the rootInjector down:

```ts
class Foo {
  dispose() {
    console.log('Foo disposed');
  }
}
const rootInjector = createInjector();
const fooProvider = rootInjector.provideClass('foo', Foo);
fooProvider.resolve('foo');
await rootInjector.dispose(); // => "Foo disposed"
rootInjector.provideClass('bar', Bar); // Error: Injector already disposed
```

Because now an `Injector` has to keep track of its child injectors, the `rootInjector` would no longer be stateless. That's why it is removed altogether. Developers are expected to create their own (root) injector using `createInjector()`.

BREAKING CHANGE: `rootInjector` is removed in favor of `createInjector`.

This:

```
import { rootInjector } from 'typed-inject';
```

Becomes:

```
import { createInjector } from 'typed-inject';
const rootInjector = createInjector();
```

Injector's created from `createInjector` are no longer stateless. They
keep track of their child injectors.

BREAKING CHANGE: `dispose` no longer disposes parent injector, disposes
the child injectors instead. See readme for more details.

Fixes #24  