### PR TITLE
note strictFunctionTypes is required; add an interface test

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ yarn add typed-inject
 
 _Note: this package uses advanced TypeScript features. Only TS 3.0 and above is supported!_
 
-_Note: due to a [bug in TypeScript 3.8](https://github.com/microsoft/TypeScript/issues/37400) there is a small chance that the compiler [doesn't catch all errors](https://github.com/nicojs/typed-inject/issues/20) (as well as you might experience some performance issues)._
+_Note: due to a [bug since TypeScript 3.8](https://github.com/microsoft/TypeScript/issues/37400) there is a small chance that the compiler [doesn't catch all errors](https://github.com/nicojs/typed-inject/issues/20) (as well as you might experience some performance issues)._
 
-_Note: projects must enable `strictFunctionTypes` in their Typescript config or some type errors may not be caught._
+_Note: projects must enable [`--strictFunctionTypes`](https://www.typescriptlang.org/tsconfig#strictFunctionTypes) (or `--strict`) in their Typescript config or some type errors may not be caught._
 
 <a name="usage"></a>
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ _Note: this package uses advanced TypeScript features. Only TS 3.0 and above is 
 
 _Note: due to a [bug in TypeScript 3.8](https://github.com/microsoft/TypeScript/issues/37400) there is a small chance that the compiler [doesn't catch all errors](https://github.com/nicojs/typed-inject/issues/20) (as well as you might experience some performance issues)._
 
+_Note: projects must enable `strictFunctionTypes` in their Typescript config or some type errors may not be caught._
+
 <a name="usage"></a>
 
 ## 🎁 Usage

--- a/testResources/tokens-of-interfaces.ts
+++ b/testResources/tokens-of-interfaces.ts
@@ -1,0 +1,27 @@
+// error: "Property 'sayFoo' is missing in type 'Bar' but required in type 'FooLike'."
+import { createInjector } from '../src/index';
+
+const rootInjector = createInjector();
+
+interface FooLike {
+  sayFoo(): void;
+}
+
+class FooPrinter implements FooLike {
+  sayFoo(): void {
+    console.log("foo!");
+  }
+}
+
+class Bar {}
+
+class Baz {
+  static inject = ["foo"] as const
+  constructor(private foo: FooLike) { }
+  callFoo(): void {
+    this.foo.sayFoo();
+  }
+}
+
+const fooInjector = rootInjector.provideClass('foo', Bar);
+const baz: Baz = fooInjector.injectClass(Baz);


### PR DESCRIPTION
Thanks for creating this library! I've tried multiple IoC containers and this is the first that is actually type-safe at compile time. 👍 

I ran into a problem integrating this into my codebase: empty classes were able to satisfy type checking for `provideClass()`, even if the class didn't fulfill an interface.

I added a test to type-inject, `testResources/tokens-of-interfaces.ts`, which showed no issue with type-inject (included in this PR; it may be redundant with other tests?).

It appears `strictFunctionTypes` must be set to `true` for empty classes to be properly checked (typed-inject uses `"strict": true`). A note is added to the `README.md` to for this requirement.