### PR TITLE
Remove injector from parent on dispose

### DIFF
--- a/test/unit/Injector.spec.ts
+++ b/test/unit/Injector.spec.ts
@@ -481,6 +481,14 @@ describe('InjectorImpl', () => {
       expect(fooDisposeStub).called;
     });
 
+    it('should be removed from parent on disposal', async () => {
+      const root = createInjector();
+      const child = root.provideValue('a', 'a');
+      await child.dispose();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect((root as any).childInjectors.size).eq(0);
+    });
+
     it("should not dispose it's parent provider", async () => {
       // Arrange
       class Grandparent {


### PR DESCRIPTION
This might not be acceptable, but it felt like the simplest solution is to use a map for tracking child injectors.

While I haven't run performance regression testing, I believe this change does slow down pretty much every operation involving children:

- provide* went from an array push to a map set, which I believe is slower
- provide* also now constructs a symbol and an arrow function (also an array temporarily for a return value, though this can be inlined)
- Dispose now must iterate over the map using for...of rather than the built-in map
- Dispose now includes a map delete (but clearing the child injectors is now unnecessary)

Initially I wanted to keep the array for storing child injectors, but tracking indices would be a nightmare.

What do you think?