### PR TITLE
feat(node): drop support for node 10 and 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git+https://github.com/nicojs/typed-inject.git"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "keywords": [
     "typescript",


### PR DESCRIPTION
Set minimal supported node version to `>=14`

BREAKING CHANGE: Node v10 and v12 are no longer supported.
