### PR TITLE
feat(Node version): set minimal node version to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git+https://github.com/nicojs/typed-inject.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "keywords": [
     "typescript",


### PR DESCRIPTION
BREAKING CHANGE: Node 14 is no longer officially supported (although it might still work).
