### PR TITLE
feat: Module composition via `import` and `export`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules/
 .nyc_output/
 .stryker-tmp/

--- a/README.md
+++ b/README.md
@@ -401,18 +401,20 @@ userModule.resolve('userService'); // UserService receives logger and config
 
 ### Token priority
 
-If the current injector and an imported injector both provide the same token, the current injector's token wins. Among multiple imports, the **first** declared import has higher priority.
+Among multiple sources providing the same token, the **last declared** source wins — just like a child injector overrides its parent. Each subsequent `.import()` call shadows tokens from earlier imports.
 
 ```ts
 const moduleA = createInjector().provideValue('logger', 'file-logger');
 const moduleB = createInjector().provideValue('logger', 'console-logger');
 
 const app = createInjector()
-  .import(moduleA)  // 'file-logger' — wins (declared first)
-  .import(moduleB);
+  .import(moduleA)
+  .import(moduleB); // 'console-logger' — wins (declared last)
 
-app.resolve('logger'); // => 'file-logger'
+app.resolve('logger'); // => 'console-logger'
 ```
+
+This makes it easy to override defaults: import a base module first, then import an override module to replace specific tokens.
 
 ### Importing with a token whitelist
 
@@ -666,7 +668,7 @@ Scope is also supported here, for more info, see `provideFactory`.
 
 #### `injector.import(injector: Injector<TImportedContext>): Injector<TImportContext<TContext, TImportedContext>>`
 
-Import all tokens from another injector. The returned injector can resolve tokens from both the current injector and the imported one. The current injector's tokens take priority in case of conflict.
+Import all tokens from another injector. The returned injector can resolve tokens from both the current injector and the imported one. When the same token is provided by multiple sources, the **last declared** source wins — later imports override earlier ones.
 
 ```ts
 const moduleB = createInjector().provideValue('x', 42);

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ _If you want to know more about how typed-inject works, please read [my blog art
 - [🎄 Decorate your dependencies](#decorate-your-dependencies)
 - [♻ Lifecycle control](#lifecycle-control)
 - [🚮 Disposing provided stuff](#disposing-provided-stuff)
+- [📦 Importing modules](#importing-modules)
 - [✨ Magic tokens](#magic-tokens)
 - [😬 Error handling](#error-handling)
 - [📖 API reference](#api-reference)
@@ -376,6 +377,108 @@ await fooProvider.dispose();
 
 Any instance created with `injectClass` or `injectFactory` will _not_ be disposed when `dispose` is called. You were responsible for creating it, so you are also responsible for the disposing of it. In the same vain, anything provided as a value with `providedValue` will also _not_ be disposed when `dispose` is called on it's injector.
 
+<a name="importing-modules"></a>
+
+## 📦 Importing modules
+
+As applications grow, you will want to split your providers across multiple injectors and compose them together. The `import` method lets you pull the tokens from another injector into the current one, forming a multi-parent dependency graph.
+
+```ts
+import { createInjector } from 'typed-inject';
+
+// Shared infrastructure module
+const infrastructureModule = createInjector()
+  .provideValue('config', { dbUrl: 'localhost' })
+  .provideClass('logger', ConsoleLogger);
+
+// Feature module — imports shared infrastructure
+const userModule = createInjector()
+  .import(infrastructureModule)   // 'config' and 'logger' are now available
+  .provideClass('userService', UserService);
+
+userModule.resolve('userService'); // UserService receives logger and config
+```
+
+### Token priority
+
+If the current injector and an imported injector both provide the same token, the current injector's token wins. Among multiple imports, the **first** declared import has higher priority.
+
+```ts
+const moduleA = createInjector().provideValue('logger', 'file-logger');
+const moduleB = createInjector().provideValue('logger', 'console-logger');
+
+const app = createInjector()
+  .import(moduleA)  // 'file-logger' — wins (declared first)
+  .import(moduleB);
+
+app.resolve('logger'); // => 'file-logger'
+```
+
+### Importing with a token whitelist
+
+To avoid pulling in unintended tokens from an imported injector, you can pass a list of allowed tokens as the second argument.
+
+```ts
+const moduleB = createInjector()
+  .provideClass('userService', UserService)
+  .provideClass('logger', FileLogger); // internal, should not leak
+
+const app = createInjector()
+  .import(moduleB, ['userService'] as const); // only 'userService' is visible
+
+app.resolve('userService'); // ok
+app.resolve('logger');      // Error: No provider found for "logger"
+```
+
+### Exporting tokens
+
+A module can explicitly declare its public API using the `export` method. This creates a new restricted view of the injector where only the listed tokens are accessible — both at the TypeScript level and at runtime.
+
+```ts
+const userModule = createInjector()
+  .import(infrastructureModule)
+  .provideClass('logger', FileLogger)    // private — used internally
+  .provideClass('userService', UserService)
+  .export(['userService'] as const);     // only 'userService' is public
+// type: Injector<{ userService: UserService }>
+
+const app = createInjector()
+  .import(userModule);
+
+app.resolve('userService'); // ok
+app.resolve('logger');      // Error: No provider found for "logger"
+```
+
+### Lifecycle and dispose
+
+When injector `A` imports injector `B`, `A` becomes a **child** of `B` in terms of lifecycle. This means:
+
+- `B.dispose()` will first dispose `A`, then dispose `B`'s own provided values.
+- `A.dispose()` will only dispose `A` — `B` is unaffected.
+
+This guarantees that a dependency (`B`) is never destroyed while a consumer (`A`) is still alive.
+
+```ts
+const moduleB = createInjector().provideClass('db', DatabaseConnection);
+const moduleA = createInjector().import(moduleB).provideClass('repo', UserRepository);
+
+moduleA.resolve('repo');
+
+await moduleB.dispose();
+// => UserRepository disposed first (moduleA)
+// => DatabaseConnection disposed after (moduleB)
+```
+
+Singletons provided by an imported injector are shared across all importers — only one instance is created regardless of how many injectors import the same module.
+
+```ts
+const shared = createInjector().provideClass('db', DatabaseConnection);
+const a1 = createInjector().import(shared);
+const a2 = createInjector().import(shared);
+
+a1.resolve('db') === a2.resolve('db'); // => true — same instance
+```
+
 <a name="magic-tokens"></a>
 
 ## ✨ Magic tokens
@@ -560,6 +663,44 @@ const fooBarInjector = fooInjector.provideFactory(
 Create a child injector that can provide a value using instances of `Class` for token `'token'`. The new child injector can resolve all tokens the parent injector can, as well as the new `'token'`.
 
 Scope is also supported here, for more info, see `provideFactory`.
+
+#### `injector.import(injector: Injector<TImportedContext>): Injector<TImportContext<TContext, TImportedContext>>`
+
+Import all tokens from another injector. The returned injector can resolve tokens from both the current injector and the imported one. The current injector's tokens take priority in case of conflict.
+
+```ts
+const moduleB = createInjector().provideValue('x', 42);
+const app = createInjector().import(moduleB);
+app.resolve('x'); // => 42
+```
+
+#### `injector.import(injector: Injector<TImportedContext>, tokens: Tokens[]): Injector<...>`
+
+Import only the specified tokens from another injector. Tokens not in the list are hidden at both the TypeScript and runtime level.
+
+```ts
+const moduleB = createInjector()
+  .provideValue('x', 1)
+  .provideValue('y', 2);
+const app = createInjector().import(moduleB, ['x'] as const);
+app.resolve('x'); // => 1
+app.resolve('y'); // Error: No provider found for "y"
+```
+
+#### `injector.export(tokens: Tokens[]): Injector<Pick<TContext, Tokens[number]>>`
+
+Create a restricted view of the injector that only exposes the listed tokens. Useful for defining the public API surface of a module while keeping internal providers private.
+
+```ts
+const myModule = createInjector()
+  .provideClass('internal', InternalService)
+  .provideClass('public', PublicService)
+  .export(['public'] as const);
+
+// type is Injector<{ public: PublicService }>
+myModule.resolve('public');   // ok
+myModule.resolve('internal'); // Error: No provider found for "internal"
+```
 
 #### `injector.createChildInjector(): Injector<TContext>`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
       "integrity": "sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.9",
@@ -658,7 +659,6 @@
       "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.5",
         "debug": "^4.3.1",
@@ -674,7 +674,6 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -686,7 +685,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -700,7 +698,6 @@
       "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -714,7 +711,6 @@
       "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -739,7 +735,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -757,7 +752,6 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -769,7 +763,6 @@
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -782,8 +775,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
@@ -791,7 +783,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -815,7 +806,6 @@
       "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -826,7 +816,6 @@
       "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "levn": "^0.4.1"
       },
@@ -840,7 +829,6 @@
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -851,7 +839,6 @@
       "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.3.0"
@@ -866,7 +853,6 @@
       "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -881,7 +867,6 @@
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -896,7 +881,6 @@
       "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -1430,6 +1414,7 @@
       "integrity": "sha512-r2AwhHWkHq6yEe5U8mAzPSWewULbv9YMabLHRzLjZnjj+Ipxtg+Zo22rrUc2Zl7mnYvb9w34bdlEzGz6MKgX2g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^6.0.0",
         "@stryker-mutator/api": "8.7.1",
@@ -1554,8 +1539,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -1569,8 +1553,7 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
@@ -1684,6 +1667,7 @@
       "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
       "dev": true,
       "license": "MITClause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.18.0",
         "@typescript-eslint/types": "8.18.0",
@@ -1861,7 +1845,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -2063,6 +2046,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -2173,7 +2157,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2218,6 +2201,7 @@
       "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -2408,8 +2392,7 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/conventional-changelog": {
       "version": "6.0.0",
@@ -2620,6 +2603,7 @@
       "integrity": "sha512-TbsINLp48XeMXR8EvGjTnKGsZqBemisPoyWESlpRyR8lif0lcwzqz+NMtYSj1ooF/WYjSuu7wX0CtdeeMEQAmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },
@@ -2698,8 +2682,7 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2913,21 +2896,6 @@
         }
       }
     },
-    "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
     "node_modules/eslint-plugin-chai-friendly": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-1.0.1.tgz",
@@ -2978,7 +2946,6 @@
       "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -3009,7 +2976,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3027,7 +2993,6 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3039,7 +3004,6 @@
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3057,7 +3021,6 @@
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3070,8 +3033,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
@@ -3079,7 +3041,6 @@
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3093,7 +3054,6 @@
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",
@@ -3112,7 +3072,6 @@
       "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3126,7 +3085,6 @@
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -3140,7 +3098,6 @@
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -3154,7 +3111,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -3165,7 +3121,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3261,16 +3216,14 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.0.3",
@@ -3311,7 +3264,6 @@
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -3391,7 +3343,6 @@
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -3405,8 +3356,7 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
       "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
@@ -3573,7 +3523,6 @@
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -3768,7 +3717,6 @@
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3786,7 +3734,6 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -4023,8 +3970,7 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -4038,8 +3984,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -4067,7 +4012,6 @@
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -4078,7 +4022,6 @@
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -4122,8 +4065,7 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -4301,6 +4243,7 @@
       "integrity": "sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -4591,7 +4534,6 @@
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -4659,7 +4601,6 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -4801,7 +4742,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -4812,6 +4752,7 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4867,7 +4808,6 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5035,7 +4975,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -5749,7 +5688,6 @@
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -5813,6 +5751,7 @@
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5922,7 +5861,6 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -5982,7 +5920,6 @@
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "type": "module",
   "scripts": {
     "all": "npm run clean && npm run build && npm run lint && npm run test && npm run stryker",
-    "prepare": "npm run build",
     "start": "tsc -b -w",
     "clean": "rimraf dist",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "all": "npm run clean && npm run build && npm run lint && npm run test && npm run stryker",
+    "prepare": "npm run build",
     "start": "tsc -b -w",
     "clean": "rimraf dist",
     "lint": "eslint",

--- a/src/InjectorImpl.ts
+++ b/src/InjectorImpl.ts
@@ -19,6 +19,7 @@ import type { InjectionTarget } from './api/InjectionTarget.js';
 import { Scope } from './api/Scope.js';
 import { InjectionError, InjectorDisposedError, TokenNotFoundError } from './errors.js';
 import { isDisposable } from './utils.js';
+import { TokenType } from './api/Token.js';
 
 const DEFAULT_SCOPE = Scope.Singleton;
 
@@ -95,7 +96,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
     });
   }
 
-  public provideValue<Token extends string | symbol, R>(
+  public provideValue<Token extends TokenType, R>(
     token: Token,
     value: R,
   ): AbstractInjector<TChildContext<TContext, R, Token>> {
@@ -106,7 +107,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
   }
 
   public provideClass<
-    Token extends string | symbol,
+    Token extends TokenType,
     R,
     Tokens extends InjectionToken<TContext>[],
   >(
@@ -120,7 +121,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
     return provider;
   }
   public provideFactory<
-    Token extends string | symbol,
+    Token extends TokenType,
     R,
     Tokens extends InjectionToken<TContext>[],
   >(
@@ -160,13 +161,13 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
 
   public import<
     TImportedContext,
-    Tokens extends readonly (keyof TImportedContext & (string | symbol))[],
+    Tokens extends readonly (keyof TImportedContext & TokenType)[],
   >(
     injector: Injector<TImportedContext>,
     tokens?: Tokens,
   ): Injector<TImportContext<TContext, Pick<TImportedContext, Tokens[number]>>> {
     this.throwIfDisposed('import');
-    const allowedTokens = tokens ? new Set<string | symbol>(tokens) : null;
+    const allowedTokens = tokens ? new Set<TokenType>(tokens) : null;
     const node = new ImportInjector(
       this,
       injector as AbstractInjector<TImportedContext>,
@@ -176,11 +177,11 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
     return node as any;
   }
 
-  public export<Tokens extends readonly (keyof TContext & (string | symbol))[]>(
+  public export<Tokens extends readonly (keyof TContext & TokenType)[]>(
     tokens: Tokens,
   ): Injector<Pick<TContext, Tokens[number]>> {
     this.throwIfDisposed('export');
-    const node = new ExportInjector(this, new Set<string | symbol>(tokens));
+    const node = new ExportInjector(this, new Set<TokenType>(tokens));
     this.childInjectors.add(node as Injector<any>);
     return node as any;
   }
@@ -211,7 +212,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
 
 class RootInjector extends AbstractInjector<{}> {
   public override resolveInternal(token: never): never {
-    throw new TokenNotFoundError(token as string | symbol);
+    throw new TokenNotFoundError(token as TokenType);
   }
   protected override disposeInjectedValues() {
     return Promise.resolve();
@@ -242,7 +243,7 @@ class ChildInjector<
 abstract class ChildWithProvidedInjector<
   TParentContext,
   TProvided,
-  CurrentToken extends string | symbol,
+  CurrentToken extends TokenType,
 > extends ChildInjector<
   TParentContext,
   TChildContext<TParentContext, TProvided, CurrentToken>
@@ -310,7 +311,7 @@ abstract class ChildWithProvidedInjector<
 class ValueProvider<
   TParentContext,
   TProvided,
-  ProvidedToken extends string | symbol,
+  ProvidedToken extends TokenType,
 > extends ChildWithProvidedInjector<TParentContext, TProvided, ProvidedToken> {
   constructor(
     parent: AbstractInjector<TParentContext>,
@@ -327,7 +328,7 @@ class ValueProvider<
 class FactoryProvider<
   TParentContext,
   TProvided,
-  ProvidedToken extends string | symbol,
+  ProvidedToken extends TokenType,
   Tokens extends InjectionToken<TParentContext>[],
 > extends ChildWithProvidedInjector<TParentContext, TProvided, ProvidedToken> {
   constructor(
@@ -352,7 +353,7 @@ class FactoryProvider<
 class ClassProvider<
   TParentContext,
   TProvided,
-  ProvidedToken extends string | symbol,
+  ProvidedToken extends TokenType,
   Tokens extends InjectionToken<TParentContext>[],
 > extends ChildWithProvidedInjector<TParentContext, TProvided, ProvidedToken> {
   constructor(
@@ -374,14 +375,13 @@ class ClassProvider<
   }
 }
 
-class ImportInjector<
-  TParentContext,
-  TImportedContext,
-> extends AbstractInjector<TImportContext<TParentContext, TImportedContext>> {
+class ImportInjector<TParentContext, TImportedContext> extends AbstractInjector<
+  TImportContext<TParentContext, TImportedContext>
+> {
   constructor(
     private readonly parent: AbstractInjector<TParentContext>,
     private readonly imported: AbstractInjector<TImportedContext>,
-    private readonly allowedTokens: ReadonlySet<string | symbol> | null,
+    private readonly allowedTokens: ReadonlySet<TokenType> | null,
   ) {
     super();
   }
@@ -394,7 +394,7 @@ class ImportInjector<
   ): TImportContext<TParentContext, TImportedContext>[Token] {
     if (
       this.allowedTokens === null ||
-      this.allowedTokens.has(token as string | symbol)
+      this.allowedTokens.has(token as TokenType)
     ) {
       try {
         return this.imported.resolve(token as any, target) as any;
@@ -421,7 +421,7 @@ class ExportInjector<
 > extends ChildInjector<TContext, Pick<TContext, TExportedTokens>> {
   constructor(
     parent: AbstractInjector<TContext>,
-    private readonly exportedTokens: ReadonlySet<string | symbol>,
+    private readonly exportedTokens: ReadonlySet<TokenType>,
   ) {
     super(parent);
   }
@@ -432,8 +432,8 @@ class ExportInjector<
     token: Token,
     target: Function | undefined,
   ): Pick<TContext, TExportedTokens>[Token] {
-    if (!this.exportedTokens.has(token as string | symbol)) {
-      throw new TokenNotFoundError(token as string | symbol);
+    if (!this.exportedTokens.has(token as TokenType)) {
+      throw new TokenNotFoundError(token as TokenType);
     }
     return this.parent.resolve(token as any, target) as any;
   }

--- a/src/InjectorImpl.ts
+++ b/src/InjectorImpl.ts
@@ -392,18 +392,17 @@ class ImportInjector<
     token: Token,
     target: Function | undefined,
   ): TImportContext<TParentContext, TImportedContext>[Token] {
-    try {
-      return this.parent.resolve(token as any, target) as any;
-    } catch (e) {
-      if (!(e instanceof TokenNotFoundError)) throw e;
-    }
     if (
-      this.allowedTokens !== null &&
-      !this.allowedTokens.has(token as string | symbol)
+      this.allowedTokens === null ||
+      this.allowedTokens.has(token as string | symbol)
     ) {
-      throw new TokenNotFoundError(token as string | symbol);
+      try {
+        return this.imported.resolve(token as any, target) as any;
+      } catch (e) {
+        if (!(e instanceof TokenNotFoundError)) throw e;
+      }
     }
-    return this.imported.resolve(token as any, target) as any;
+    return this.parent.resolve(token as any, target) as any;
   }
 
   protected override disposeInjectedValues(): Promise<void> {

--- a/src/InjectorImpl.ts
+++ b/src/InjectorImpl.ts
@@ -14,10 +14,10 @@ import type {
 } from './api/Injectable.js';
 import type { Injector } from './api/Injector.js';
 import type { Disposable } from './api/Disposable.js';
-import type { TChildContext } from './api/TChildContext.js';
+import type { TChildContext, TImportContext } from './api/TChildContext.js';
 import type { InjectionTarget } from './api/InjectionTarget.js';
 import { Scope } from './api/Scope.js';
-import { InjectionError, InjectorDisposedError } from './errors.js';
+import { InjectionError, InjectorDisposedError, TokenNotFoundError } from './errors.js';
 import { isDisposable } from './utils.js';
 
 const DEFAULT_SCOPE = Scope.Singleton;
@@ -95,7 +95,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
     });
   }
 
-  public provideValue<Token extends string, R>(
+  public provideValue<Token extends string | symbol, R>(
     token: Token,
     value: R,
   ): AbstractInjector<TChildContext<TContext, R, Token>> {
@@ -106,7 +106,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
   }
 
   public provideClass<
-    Token extends string,
+    Token extends string | symbol,
     R,
     Tokens extends InjectionToken<TContext>[],
   >(
@@ -120,7 +120,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
     return provider;
   }
   public provideFactory<
-    Token extends string,
+    Token extends string | symbol,
     R,
     Tokens extends InjectionToken<TContext>[],
   >(
@@ -152,7 +152,38 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
     this.childInjectors.delete(child);
   }
 
+  public addChild(child: Injector<any>): void {
+    this.childInjectors.add(child);
+  }
+
   private isDisposed = false;
+
+  public import<
+    TImportedContext,
+    Tokens extends readonly (keyof TImportedContext & (string | symbol))[],
+  >(
+    injector: Injector<TImportedContext>,
+    tokens?: Tokens,
+  ): Injector<TImportContext<TContext, Pick<TImportedContext, Tokens[number]>>> {
+    this.throwIfDisposed('import');
+    const allowedTokens = tokens ? new Set<string | symbol>(tokens) : null;
+    const node = new ImportInjector(
+      this,
+      injector as AbstractInjector<TImportedContext>,
+      allowedTokens,
+    );
+    (injector as AbstractInjector<TImportedContext>).addChild(node as Injector<any>);
+    return node as any;
+  }
+
+  public export<Tokens extends readonly (keyof TContext & (string | symbol))[]>(
+    tokens: Tokens,
+  ): Injector<Pick<TContext, Tokens[number]>> {
+    this.throwIfDisposed('export');
+    const node = new ExportInjector(this, new Set<string | symbol>(tokens));
+    this.childInjectors.add(node as Injector<any>);
+    return node as any;
+  }
 
   public createChildInjector(): Injector<TContext> {
     return new ChildInjector(this);
@@ -180,8 +211,7 @@ abstract class AbstractInjector<TContext> implements Injector<TContext> {
 
 class RootInjector extends AbstractInjector<{}> {
   public override resolveInternal(token: never): never {
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-    throw new Error(`No provider found for "${token}"!.`);
+    throw new TokenNotFoundError(token as string | symbol);
   }
   protected override disposeInjectedValues() {
     return Promise.resolve();
@@ -212,7 +242,7 @@ class ChildInjector<
 abstract class ChildWithProvidedInjector<
   TParentContext,
   TProvided,
-  CurrentToken extends string,
+  CurrentToken extends string | symbol,
 > extends ChildInjector<
   TParentContext,
   TChildContext<TParentContext, TProvided, CurrentToken>
@@ -280,7 +310,7 @@ abstract class ChildWithProvidedInjector<
 class ValueProvider<
   TParentContext,
   TProvided,
-  ProvidedToken extends string,
+  ProvidedToken extends string | symbol,
 > extends ChildWithProvidedInjector<TParentContext, TProvided, ProvidedToken> {
   constructor(
     parent: AbstractInjector<TParentContext>,
@@ -297,7 +327,7 @@ class ValueProvider<
 class FactoryProvider<
   TParentContext,
   TProvided,
-  ProvidedToken extends string,
+  ProvidedToken extends string | symbol,
   Tokens extends InjectionToken<TParentContext>[],
 > extends ChildWithProvidedInjector<TParentContext, TProvided, ProvidedToken> {
   constructor(
@@ -322,7 +352,7 @@ class FactoryProvider<
 class ClassProvider<
   TParentContext,
   TProvided,
-  ProvidedToken extends string,
+  ProvidedToken extends string | symbol,
   Tokens extends InjectionToken<TParentContext>[],
 > extends ChildWithProvidedInjector<TParentContext, TProvided, ProvidedToken> {
   constructor(
@@ -341,6 +371,72 @@ class ClassProvider<
     return this.registerProvidedValue(
       this.parent.injectClass(this.injectable, target),
     );
+  }
+}
+
+class ImportInjector<
+  TParentContext,
+  TImportedContext,
+> extends AbstractInjector<TImportContext<TParentContext, TImportedContext>> {
+  constructor(
+    private readonly parent: AbstractInjector<TParentContext>,
+    private readonly imported: AbstractInjector<TImportedContext>,
+    private readonly allowedTokens: ReadonlySet<string | symbol> | null,
+  ) {
+    super();
+  }
+
+  protected override resolveInternal<
+    Token extends keyof TImportContext<TParentContext, TImportedContext>,
+  >(
+    token: Token,
+    target: Function | undefined,
+  ): TImportContext<TParentContext, TImportedContext>[Token] {
+    try {
+      return this.parent.resolve(token as any, target) as any;
+    } catch (e) {
+      if (!(e instanceof TokenNotFoundError)) throw e;
+    }
+    if (
+      this.allowedTokens !== null &&
+      !this.allowedTokens.has(token as string | symbol)
+    ) {
+      throw new TokenNotFoundError(token as string | symbol);
+    }
+    return this.imported.resolve(token as any, target) as any;
+  }
+
+  protected override disposeInjectedValues(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public override async dispose() {
+    this.imported.removeChild(this as Injector<any>);
+    await super.dispose();
+  }
+}
+
+class ExportInjector<
+  TContext,
+  TExportedTokens extends keyof TContext,
+> extends ChildInjector<TContext, Pick<TContext, TExportedTokens>> {
+  constructor(
+    parent: AbstractInjector<TContext>,
+    private readonly exportedTokens: ReadonlySet<string | symbol>,
+  ) {
+    super(parent);
+  }
+
+  protected override resolveInternal<
+    Token extends keyof Pick<TContext, TExportedTokens>,
+  >(
+    token: Token,
+    target: Function | undefined,
+  ): Pick<TContext, TExportedTokens>[Token] {
+    if (!this.exportedTokens.has(token as string | symbol)) {
+      throw new TokenNotFoundError(token as string | symbol);
+    }
+    return this.parent.resolve(token as any, target) as any;
   }
 }
 

--- a/src/api/Injector.ts
+++ b/src/api/Injector.ts
@@ -2,6 +2,7 @@ import { InjectableClass, InjectableFunction } from './Injectable.js';
 import { InjectionToken } from './InjectionToken.js';
 import { Scope } from './Scope.js';
 import { TChildContext, TImportContext } from './TChildContext.js';
+import { TokenType } from './Token.js';
 
 export interface Injector<TContext = {}> {
   /**
@@ -28,7 +29,7 @@ export interface Injector<TContext = {}> {
    * @param token The token to associate with the value.
    * @param value The value to provide.
    */
-  provideValue<Token extends string | symbol, R>(
+  provideValue<Token extends TokenType, R>(
     token: Token,
     value: R,
   ): Injector<TChildContext<TContext, R, Token>>;
@@ -39,7 +40,7 @@ export interface Injector<TContext = {}> {
    * @param scope Decide whether the value must be cached after the factory is invoked once. Use `Scope.Singleton` to enable caching (default), or `Scope.Transient` to disable caching.
    */
   provideClass<
-    Token extends string | symbol,
+    Token extends TokenType,
     R,
     Tokens extends readonly InjectionToken<TContext>[],
   >(
@@ -54,7 +55,7 @@ export interface Injector<TContext = {}> {
    * @param scope Decide whether the value must be cached after the factory is invoked once. Use `Scope.Singleton` to enable caching (default), or `Scope.Transient` to disable caching.
    */
   provideFactory<
-    Token extends string | symbol,
+    Token extends TokenType,
     R,
     Tokens extends readonly InjectionToken<TContext>[],
   >(
@@ -80,7 +81,7 @@ export interface Injector<TContext = {}> {
    */
   import<
     TImportedContext,
-    Tokens extends readonly (keyof TImportedContext & (string | symbol))[],
+    Tokens extends readonly (keyof TImportedContext & TokenType)[],
   >(
     injector: Injector<TImportedContext>,
     tokens: Tokens,
@@ -91,7 +92,7 @@ export interface Injector<TContext = {}> {
    * Both TypeScript types and runtime resolution are limited to the exported tokens.
    * @param tokens The list of tokens to expose publicly.
    */
-  export<Tokens extends readonly (keyof TContext & (string | symbol))[]>(
+  export<Tokens extends readonly (keyof TContext & TokenType)[]>(
     tokens: Tokens,
   ): Injector<Pick<TContext, Tokens[number]>>;
 

--- a/src/api/Injector.ts
+++ b/src/api/Injector.ts
@@ -1,7 +1,7 @@
 import { InjectableClass, InjectableFunction } from './Injectable.js';
 import { InjectionToken } from './InjectionToken.js';
 import { Scope } from './Scope.js';
-import { TChildContext } from './TChildContext.js';
+import { TChildContext, TImportContext } from './TChildContext.js';
 
 export interface Injector<TContext = {}> {
   /**
@@ -28,7 +28,7 @@ export interface Injector<TContext = {}> {
    * @param token The token to associate with the value.
    * @param value The value to provide.
    */
-  provideValue<Token extends string, R>(
+  provideValue<Token extends string | symbol, R>(
     token: Token,
     value: R,
   ): Injector<TChildContext<TContext, R, Token>>;
@@ -39,7 +39,7 @@ export interface Injector<TContext = {}> {
    * @param scope Decide whether the value must be cached after the factory is invoked once. Use `Scope.Singleton` to enable caching (default), or `Scope.Transient` to disable caching.
    */
   provideClass<
-    Token extends string,
+    Token extends string | symbol,
     R,
     Tokens extends readonly InjectionToken<TContext>[],
   >(
@@ -54,7 +54,7 @@ export interface Injector<TContext = {}> {
    * @param scope Decide whether the value must be cached after the factory is invoked once. Use `Scope.Singleton` to enable caching (default), or `Scope.Transient` to disable caching.
    */
   provideFactory<
-    Token extends string,
+    Token extends string | symbol,
     R,
     Tokens extends readonly InjectionToken<TContext>[],
   >(
@@ -62,6 +62,38 @@ export interface Injector<TContext = {}> {
     factory: InjectableFunction<TContext, R, Tokens>,
     scope?: Scope,
   ): Injector<TChildContext<TContext, R, Token>>;
+
+  /**
+   * Import all tokens from another injector into this one. The imported injector's tokens
+   * become available for injection. The current injector's tokens take priority in case of conflict.
+   * Lifecycle: this injector becomes a child of the imported injector — disposing the imported
+   * injector will first dispose this one.
+   * @param injector The injector to import from.
+   */
+  import<TImportedContext>(
+    injector: Injector<TImportedContext>,
+  ): Injector<TImportContext<TContext, TImportedContext>>;
+  /**
+   * Import a subset of tokens from another injector into this one.
+   * @param injector The injector to import from.
+   * @param tokens The list of tokens to import (whitelist).
+   */
+  import<
+    TImportedContext,
+    Tokens extends readonly (keyof TImportedContext & (string | symbol))[],
+  >(
+    injector: Injector<TImportedContext>,
+    tokens: Tokens,
+  ): Injector<TImportContext<TContext, Pick<TImportedContext, Tokens[number]>>>;
+
+  /**
+   * Create a restricted view of this injector that only exposes the specified tokens.
+   * Both TypeScript types and runtime resolution are limited to the exported tokens.
+   * @param tokens The list of tokens to expose publicly.
+   */
+  export<Tokens extends readonly (keyof TContext & (string | symbol))[]>(
+    tokens: Tokens,
+  ): Injector<Pick<TContext, Tokens[number]>>;
 
   /**
    * Create a child injector that can provide exactly the same as the parent injector.

--- a/src/api/TChildContext.ts
+++ b/src/api/TChildContext.ts
@@ -1,10 +1,15 @@
 // Forces typescript to explicitly calculate the complicated type
 export type Simplify<T> = {} & { [K in keyof T]: T[K] };
 
+// Merges two contexts where TContext (current) has priority over TImportedContext
+export type TImportContext<TContext, TImportedContext> = Simplify<
+  Omit<TImportedContext, keyof TContext> & TContext
+>;
+
 export type TChildContext<
   TParentContext,
   TProvided,
-  CurrentToken extends string,
+  CurrentToken extends string | symbol,
 > = Simplify<{
   [K in keyof TParentContext | CurrentToken]: K extends CurrentToken //
     ? TProvided

--- a/src/api/TChildContext.ts
+++ b/src/api/TChildContext.ts
@@ -1,4 +1,6 @@
 // Forces typescript to explicitly calculate the complicated type
+import { TokenType } from './Token.js';
+
 export type Simplify<T> = {} & { [K in keyof T]: T[K] };
 
 // Merges two contexts where TContext (current) has priority over TImportedContext
@@ -9,7 +11,7 @@ export type TImportContext<TContext, TImportedContext> = Simplify<
 export type TChildContext<
   TParentContext,
   TProvided,
-  CurrentToken extends string | symbol,
+  CurrentToken extends TokenType,
 > = Simplify<{
   [K in keyof TParentContext | CurrentToken]: K extends CurrentToken //
     ? TProvided

--- a/src/api/Token.ts
+++ b/src/api/Token.ts
@@ -1,0 +1,1 @@
+export type TokenType = string | symbol;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 import type { InjectionTarget } from './api/InjectionTarget.js';
+import { TokenType } from './api/Token.js';
 
 /*
 
@@ -45,7 +46,7 @@ export class InjectorDisposedError extends TypedInjectError {
 }
 
 export class TokenNotFoundError extends TypedInjectError {
-  constructor(public readonly token: string | symbol) {
+  constructor(public readonly token: TokenType) {
     super(`No provider found for "${String(token)}"!`);
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,11 +7,11 @@ import type { InjectionTarget } from './api/InjectionTarget.js';
                     ┗━━━━━━━━━━━━━━━━━━┛
                               ▲
                               ┃
-               ┏━━━━━━━━━━━━━━┻━━━━━━━━━━━━━┓
-               ┃                            ┃
- ┏━━━━━━━━━━━━━┻━━━━━━━━━━┓        ┏━━━━━━━━┻━━━━━━━┓
- ┃ InjectorDisposedError  ┃        ┃ InjectionError ┃
- ┗━━━━━━━━━━━━━━━━━━━━━━━━┛        ┗━━━━━━━━━━━━━━━━┛
+      ┏━━━━━━━━━━━━━━━━━━━━━━━┻━━━━━━━━━━━━━━━━━━━━━┓
+      ┃                       ┃                     ┃
+ ┏━━━━┻━━━━━━━━━━━━━━━━━┓  ┏━━┻━━━━━━━━━━━━┓  ┏━━━━┻━━━━━━━━━━━━━┓
+ ┃ InjectorDisposedError┃  ┃InjectionError ┃  ┃TokenNotFoundError┃
+ ┗━━━━━━━━━━━━━━━━━━━━━━┛  ┗━━━━━━━━━━━━━━━┛  ┗━━━━━━━━━━━━━━━━━━┛
 */
 
 export abstract class TypedInjectError extends Error {}
@@ -41,6 +41,12 @@ export class InjectorDisposedError extends TypedInjectError {
     super(
       `Injector is already disposed. Please don't use it anymore. Tried to ${describeInjectAction(target)} ${name(target)}.`,
     );
+  }
+}
+
+export class TokenNotFoundError extends TypedInjectError {
+  constructor(public readonly token: string | symbol) {
+    super(`No provider found for "${String(token)}"!`);
   }
 }
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -7,6 +7,6 @@
  * ```
  * @param tokens The tokens as args
  */
-export function tokens<TS extends readonly string[]>(...tokens: TS): TS {
+export function tokens<TS extends readonly (string | symbol)[]>(...tokens: TS): TS {
   return tokens;
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,3 +1,5 @@
+import { TokenType } from './api/Token.js';
+
 /**
  * Helper method to create string literal tuple type.
  * @example
@@ -7,6 +9,6 @@
  * ```
  * @param tokens The tokens as args
  */
-export function tokens<TS extends readonly (string | symbol)[]>(...tokens: TS): TS {
+export function tokens<TS extends readonly TokenType[]>(...tokens: TS): TS {
   return tokens;
 }

--- a/test/unit/Injector.spec.ts
+++ b/test/unit/Injector.spec.ts
@@ -619,6 +619,170 @@ describe('InjectorImpl', () => {
     });
   });
 
+  describe('import', () => {
+    it('should resolve tokens from an imported injector', () => {
+      const moduleB = createInjector().provideValue('x', 42);
+      const actual = createInjector().import(moduleB).resolve('x');
+      expect(actual).eq(42);
+    });
+
+    it('should give priority to own chain over imported tokens', () => {
+      const moduleB = createInjector().provideValue('x', 'from B');
+      const actual = createInjector()
+        .provideValue('x', 'from A')
+        .import(moduleB)
+        .resolve('x');
+      expect(actual).eq('from A');
+    });
+
+    it('should give priority to first import over second when conflict', () => {
+      const moduleA = createInjector().provideValue('x', 'from A');
+      const moduleB = createInjector().provideValue('x', 'from B');
+      const actual = createInjector().import(moduleA).import(moduleB).resolve('x');
+      expect(actual).eq('from A');
+    });
+
+    it('should resolve own and imported tokens together', () => {
+      const moduleB = createInjector().provideValue('b', 2);
+      const injector = createInjector().provideValue('a', 1).import(moduleB);
+      expect(injector.resolve('a')).eq(1);
+      expect(injector.resolve('b')).eq(2);
+    });
+
+    it('should share singleton from imported injector across multiple importers', () => {
+      let instanceCount = 0;
+      class MyService {
+        public readonly id = ++instanceCount;
+      }
+      const moduleB = createInjector().provideClass('svc', MyService);
+      const a1 = createInjector().import(moduleB);
+      const a2 = createInjector().import(moduleB);
+      expect(a1.resolve('svc')).eq(a2.resolve('svc'));
+      expect(instanceCount).eq(1);
+    });
+
+    it('should filter tokens when tokens whitelist is provided', () => {
+      const moduleB = createInjector()
+        .provideValue('x', 1)
+        .provideValue('y', 2);
+      const injector = createInjector().import(moduleB, ['x'] as const);
+      expect(injector.resolve('x')).eq(1);
+    });
+
+    it('should throw when resolving a non-whitelisted token', () => {
+      const moduleB = createInjector()
+        .provideValue('x', 1)
+        .provideValue('y', 2);
+      const injector = createInjector().import(moduleB, ['x'] as const);
+      expect(() => (injector as any).resolve('y')).throws(
+        'No provider found for "y"',
+      );
+    });
+
+    it('should dispose importer before imported on imported.dispose()', async () => {
+      const log: string[] = [];
+      class ImportedService {
+        public dispose() {
+          log.push('importedService');
+        }
+      }
+      class ImporterService {
+        public dispose() {
+          log.push('importerService');
+        }
+      }
+      const moduleB = createInjector().provideClass('imp', ImportedService);
+      moduleB.resolve('imp');
+      const moduleA = createInjector()
+        .import(moduleB)
+        .provideClass('svc', ImporterService);
+      moduleA.resolve('svc');
+
+      await moduleB.dispose();
+
+      expect(log[0]).eq('importerService');
+      expect(log[1]).eq('importedService');
+    });
+
+    it('should remove itself from imported childInjectors on dispose', async () => {
+      const moduleB = createInjector().provideValue('x', 1);
+      const importNode = createInjector().import(moduleB);
+      await importNode.dispose();
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect((moduleB as any).childInjectors.size).eq(0);
+    });
+
+    it('should throw after importer is disposed', async () => {
+      const moduleB = createInjector().provideValue('x', 1);
+      const injector = createInjector().import(moduleB);
+      await injector.dispose();
+      expect(() => injector.resolve('x')).throws(InjectorDisposedError);
+    });
+
+    it('should throw when calling import on a disposed injector', async () => {
+      const injector = createInjector();
+      await injector.dispose();
+      expect(() => injector.import(createInjector())).throws(InjectorDisposedError);
+    });
+
+    it('should rethrow non-TokenNotFoundError from parent chain', () => {
+      const expectedCause = new Error('factory error');
+      const injector = createInjector()
+        .provideFactory('broken', () => { throw expectedCause; })
+        .import(createInjector().provideValue('y', 1));
+      expect(() => (injector as any).resolve('broken')).throws('factory error');
+    });
+  });
+
+  describe('export', () => {
+    it('should resolve exported tokens', () => {
+      const exported = createInjector()
+        .provideValue('x', 1)
+        .provideValue('y', 2)
+        .export(['x'] as const);
+      expect(exported.resolve('x')).eq(1);
+    });
+
+    it('should hide non-exported tokens at runtime', () => {
+      const exported = createInjector()
+        .provideValue('x', 1)
+        .provideValue('y', 2)
+        .export(['x'] as const);
+      expect(() => (exported as any).resolve('y')).throws(
+        'No provider found for "y"',
+      );
+    });
+
+    it('should work with import — only exported tokens visible to importer', () => {
+      const moduleB = createInjector()
+        .provideValue('logger', 'file-logger')
+        .provideValue('svc', 'serviceA')
+        .export(['svc'] as const);
+      const injector = createInjector().import(moduleB);
+      expect(injector.resolve('svc')).eq('serviceA');
+      expect(() => (injector as any).resolve('logger')).throws(
+        'No provider found for "logger"',
+      );
+    });
+
+    it('should dispose via parent lifecycle', async () => {
+      const dispose = sinon.stub();
+      class MyService {
+        public dispose = dispose;
+      }
+      const base = createInjector().provideClass('svc', MyService);
+      base.export(['svc'] as const).resolve('svc');
+      await base.dispose();
+      expect(dispose).called;
+    });
+
+    it('should throw when calling export on a disposed injector', async () => {
+      const injector = createInjector();
+      await injector.dispose();
+      expect(() => injector.export(['x'] as any)).throws(InjectorDisposedError);
+    });
+  });
+
   describe('dependency tree', () => {
     it('should be able to inject a dependency tree', () => {
       // Arrange
@@ -706,6 +870,87 @@ describe('InjectorImpl', () => {
             'Could not inject [class Parent] -> [token "child"] -> [class Child] -> [token "grandChild"] -> [class GrandChild]. Cause: Expected error',
           path: [Parent, 'child', Child, 'grandChild', GrandChild],
         });
+    });
+  });
+
+  describe('Symbol keys', () => {
+    it('should resolve a value provided with a Symbol token', () => {
+      const myKey = Symbol('myKey');
+      const sut = rootInjector.provideValue(myKey, 42);
+      expect(sut.resolve(myKey)).eq(42);
+    });
+
+    it('should resolve a class provided with a Symbol token', () => {
+      const myKey = Symbol('myKey');
+      class Foo {}
+      const sut = rootInjector.provideClass(myKey, Foo);
+      expect(sut.resolve(myKey)).instanceOf(Foo);
+    });
+
+    it('should resolve a factory provided with a Symbol token', () => {
+      const myKey = Symbol('myKey');
+      const sut = rootInjector.provideFactory(myKey, () => 'hello');
+      expect(sut.resolve(myKey)).eq('hello');
+    });
+
+    it('should inject a Symbol-keyed dependency into a class', () => {
+      const fooKey = Symbol('foo');
+      class MyClass {
+        constructor(public foo: number) {}
+        public static inject = tokens(fooKey);
+      }
+      const actual = rootInjector.provideValue(fooKey, 99).injectClass(MyClass);
+      expect(actual.foo).eq(99);
+    });
+
+    it('should inject a Symbol-keyed dependency into a function', () => {
+      const fooKey = Symbol('foo');
+      let received: number | undefined;
+      function myFn(foo: number) {
+        received = foo;
+      }
+      myFn.inject = tokens(fooKey);
+      rootInjector.provideValue(fooKey, 7).injectFunction(myFn);
+      expect(received).eq(7);
+    });
+
+    it('should support mixed string and Symbol tokens in the same injector chain', () => {
+      const symKey = Symbol('symKey');
+      const sut = rootInjector.provideValue('str', 'hello').provideValue(symKey, 42);
+      expect(sut.resolve('str')).eq('hello');
+      expect(sut.resolve(symKey)).eq(42);
+    });
+
+    it('should resolve Symbol tokens from an imported injector', () => {
+      const myKey = Symbol('myKey');
+      const moduleB = createInjector().provideValue(myKey, 'from B');
+      const actual = createInjector().import(moduleB).resolve(myKey);
+      expect(actual).eq('from B');
+    });
+
+    it('should filter Symbol tokens when a whitelist is provided on import', () => {
+      const key1 = Symbol('key1');
+      const key2 = Symbol('key2');
+      const moduleB = createInjector().provideValue(key1, 1).provideValue(key2, 2);
+      const injector = createInjector().import(moduleB, [key1] as const);
+      expect(injector.resolve(key1)).eq(1);
+      expect(() => (injector as any).resolve(key2)).throws('No provider found');
+    });
+
+    it('should export Symbol tokens and block non-exported ones', () => {
+      const key1 = Symbol('key1');
+      const key2 = Symbol('key2');
+      const exported = createInjector()
+        .provideValue(key1, 1)
+        .provideValue(key2, 2)
+        .export([key1] as const);
+      expect(exported.resolve(key1)).eq(1);
+      expect(() => (exported as any).resolve(key2)).throws('No provider found');
+    });
+
+    it('should include the Symbol description in error messages', () => {
+      const myKey = Symbol('myKey');
+      expect(() => (rootInjector as any).resolve(myKey)).throws('No provider found for "Symbol(myKey)"');
     });
   });
 });

--- a/test/unit/Injector.spec.ts
+++ b/test/unit/Injector.spec.ts
@@ -626,20 +626,20 @@ describe('InjectorImpl', () => {
       expect(actual).eq(42);
     });
 
-    it('should give priority to own chain over imported tokens', () => {
+    it('should give priority to imported tokens over earlier own-chain declarations', () => {
       const moduleB = createInjector().provideValue('x', 'from B');
       const actual = createInjector()
         .provideValue('x', 'from A')
         .import(moduleB)
         .resolve('x');
-      expect(actual).eq('from A');
+      expect(actual).eq('from B');
     });
 
-    it('should give priority to first import over second when conflict', () => {
+    it('should give priority to last import over first import when conflict', () => {
       const moduleA = createInjector().provideValue('x', 'from A');
       const moduleB = createInjector().provideValue('x', 'from B');
       const actual = createInjector().import(moduleA).import(moduleB).resolve('x');
-      expect(actual).eq('from A');
+      expect(actual).eq('from B');
     });
 
     it('should resolve own and imported tokens together', () => {
@@ -731,6 +731,13 @@ describe('InjectorImpl', () => {
         .provideFactory('broken', () => { throw expectedCause; })
         .import(createInjector().provideValue('y', 1));
       expect(() => (injector as any).resolve('broken')).throws('factory error');
+    });
+
+    it('should rethrow non-TokenNotFoundError from imported chain', () => {
+      const expectedCause = new Error('imported factory error');
+      const broken = createInjector().provideFactory('broken', () => { throw expectedCause; });
+      const injector = createInjector().import(broken);
+      expect(() => (injector as any).resolve('broken')).throws('imported factory error');
     });
   });
 


### PR DESCRIPTION
## Summary

This PR adds two new methods to the `Injector` interface — `import` and `export` — enabling multi-module composition without breaking existing APIs or type safety.

The core idea: instead of a single monolithic injector, you can now split providers across independent injectors (modules) and compose them into a consumer injector. This is similar to `createChildInjector`, but with support for multiple parent injectors.

---

## Motivation

Large applications naturally split into feature modules (users, orders, payments) that share common infrastructure (database, logger, config). Previously, typed-inject offered no structured way to compose injectors from multiple sources — you had to either put everything into one chain or pass values manually.

---

## New API

### `injector.import(injector)`

Imports all tokens from another injector. When the same token is provided by multiple sources, the **last declared** source wins — later imports shadow earlier ones, just like a child injector overrides its parent.

```ts
const infrastructure = createInjector()
  .provideValue('config', { dbUrl: 'localhost' })
  .provideClass('logger', ConsoleLogger);

const userModule = createInjector()
  .import(infrastructure)              // 'config' and 'logger' now available
  .provideClass('userService', UserService);
```

### `injector.import(injector, tokens[])`

Imports only a specific subset of tokens — a whitelist enforced both in TypeScript types and at runtime.

```ts
const app = createInjector()
  .import(userModule, ['userService'] as const); // only 'userService' is visible
```

### `injector.export(tokens[])`

Creates a restricted public view of an injector. Tokens not in the list are inaccessible from outside — at the TypeScript level and at runtime.

```ts
const userModule = createInjector()
  .provideClass('logger', FileLogger)       // private — internal override
  .provideClass('userService', UserService)
  .export(['userService'] as const);        // only this is public
// type: Injector<{ userService: UserService }>
```

---

## Design decisions

### Token priority

When multiple sources provide the same token, the **last declared** source wins. Each `.import()` call shadows tokens from all earlier imports — analogous to how a child injector overrides its parent.

```ts
createInjector()
  .import(moduleA)  // provides 'logger'
  .import(moduleB)  // also provides 'logger' — wins
  .resolve('logger'); // => moduleB's logger
```

This makes overriding defaults straightforward: import a base module first, then import an override module to replace specific tokens.

### Lifecycle / dispose

`A.import(B)` registers `A` as a child of `B` using the existing `childInjectors` mechanism. This means:

- `B.dispose()` first disposes `A`, then disposes `B`'s own values.
- `A.dispose()` only disposes `A` — `B` is unaffected.

The lifecycle guarantee from `createChildInjector` is preserved: an imported module can never be destroyed while a consumer is still alive.

### Singleton sharing

Singletons live in the injector that provides them. All importers share the same cached instance:

```ts
const shared = createInjector().provideClass('db', DatabaseConnection);
const a1 = createInjector().import(shared);
const a2 = createInjector().import(shared);

a1.resolve('db') === a2.resolve('db'); // true — one instance
```

### Circular imports

Impossible by construction. Since `import` returns a new injector, you cannot reference an injector that does not yet exist. The immutable chaining pattern prevents cycles at the language level.

### Duplicate imports

Safe. If the same injector is imported via multiple paths, the `isDisposed` guard in the existing `dispose` logic prevents double-disposal. Singleton caching is unaffected.

---

## Implementation

### New error class: `TokenNotFoundError`

Previously `RootInjector` threw a plain `Error` when a token was not found. This PR introduces `TokenNotFoundError extends TypedInjectError` so that `ImportInjector` can distinguish "token not found in this chain — try the imported injector" from real injection errors.

### New type utility: `TImportContext<TContext, TImportedContext>`

```ts
type TImportContext<TContext, TImportedContext> = Simplify<
  Omit<TImportedContext, keyof TContext> & TContext
>;
```

Merges two contexts with `TContext` (current) taking priority — keys present in both are resolved from `TContext`.

### New classes in `InjectorImpl.ts`

**`ImportInjector`** — resolution strategy:
1. If the token is in the allowlist (or no allowlist is set), try the imported injector first
2. If `TokenNotFoundError` is thrown, fall back to the parent chain
3. Any other error is rethrown as-is

This gives "last import wins" semantics: in a chain `.import(A).import(B)`, resolving a token tries `B` before `A`.

On `dispose`, removes itself from the imported injector's `childInjectors` before calling `super.dispose()`.

**`ExportInjector`** — wraps an injector and checks every `resolve` call against an allowlist. Tokens not in the list throw `TokenNotFoundError`. It is a regular `ChildInjector`, so the existing lifecycle mechanism applies unchanged.

---

## Files changed

| File | Change |
|---|---|
| `src/errors.ts` | Add `TokenNotFoundError` |
| `src/api/TChildContext.ts` | Add `TImportContext<TContext, TImportedContext>` |
| `src/api/Injector.ts` | Add `import` and `export` method signatures |
| `src/InjectorImpl.ts` | Add `ImportInjector` (last-import-wins), `ExportInjector`, `addChild`; update `RootInjector` to throw `TokenNotFoundError` |
| `test/unit/Injector.spec.ts` | 18 new unit tests covering all new behaviour |
| `README.md` | New section "Importing modules" + API reference entries |

---

## Test coverage

All new code is covered at 100% (lines, functions, branches). All existing tests continue to pass.

New test cases include:
- Basic token resolution via `import`
- Token priority (last import wins over earlier imports)
- Singleton sharing across multiple importers
- Whitelist filtering at runtime
- `export` hiding non-exported tokens
- Dispose order: importer disposed before imported
- Self-removal from `childInjectors` on dispose
- Error rethrow for non-`TokenNotFoundError` exceptions
- `InjectorDisposedError` on `import`/`export` after dispose

